### PR TITLE
[design] 폰트, 색상 변수 선언

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,7 +1,23 @@
+@import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css");
+
+:root {
+  --color-brand-main: #ff7f50;
+  --color-brand-orange: #ffa07a;
+  --color-brand-yellow: #ffdb7b;
+  --color-brand-darkgray: #545454;
+  --color-brand-gray: #9b9b9b;
+  --color-brand-lightgray: #c4c4c4;
+  --color-error: #ff6228;
+  --color-pass: #03ca5f;
+  --color-black: #353535;
+  --color-white: #ffffff;
+}
+
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu",
-    "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  /* font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu",
+    "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif; */
+  font-family: "Pretendard", sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }


### PR DESCRIPTION
1. 폰트
  - pretendard 폰트 추가

2. 색상 변수 선언 :root { --color-brand-main: #ff7f50; --color-brand-orange: #ffa07a; --color-brand-yellow: #ffdb7b; --color-brand-darkgray: #545454; --color-brand-gray: #9b9b9b; --color-brand-lightgray: #c4c4c4; --color-error: #ff6228; --color-pass: #03ca5f; --color-black: #353535; --color-white: #ffffff; }